### PR TITLE
Replace the `chatops_id` string with `nicknames` dict

### DIFF
--- a/st2auth/st2auth/controllers/v1/auth.py
+++ b/st2auth/st2auth/controllers/v1/auth.py
@@ -21,8 +21,8 @@ from six.moves import http_client
 from oslo_config import cfg
 
 from st2common.exceptions.auth import TokenNotFoundError, TokenExpiredError
-from st2common.exceptions.auth import UserNotFoundError, AmbiguousUserError
-from st2common.exceptions.auth import NoNicknameOriginProvidedError, TTLTooLargeException
+from st2common.exceptions.auth import TTLTooLargeException, UserNotFoundError
+from st2common.exceptions.auth import NoNicknameOriginProvidedError, AmbiguousUserError
 from st2common.models.api.base import jsexpose
 from st2common.models.api.auth import TokenAPI
 from st2common.persistence.auth import User
@@ -127,23 +127,24 @@ class TokenController(rest.RestController):
         if result is True:
             ttl = getattr(request, 'ttl', None)
             impersonate_user = getattr(request, 'user', None)
+
             if impersonate_user is not None:
                 username = impersonate_user
             else:
                 impersonate_user = getattr(request, 'impersonate_user', None)
-                nickname_origin = getattr(request, 'impersonate_from', None)
+                nickname_origin = getattr(request, 'nickname_origin', None)
             if impersonate_user is not None:
                 try:
                     username = User.get_by_nickname(impersonate_user, nickname_origin).username
-                except NoNicknameOriginProvidedError:
-                    message = "Nickname origin is not provided for nickname '%s'" % \
-                              impersonate_user
-                    self._abort_request(status_code=http_client.BAD_REQUEST,
-                                        message=message)
-                    return
                 except UserNotFoundError:
                     message = "Could not locate user %s@%s" % \
                               (impersonate_user, nickname_origin)
+                    self._abort_request(status_code=http_client.BAD_REQUEST,
+                                        message=message)
+                    return
+                except NoNicknameOriginProvidedError:
+                    message = "Nickname origin is not provided for nickname '%s'" % \
+                              impersonate_user
                     self._abort_request(status_code=http_client.BAD_REQUEST,
                                         message=message)
                     return

--- a/st2auth/st2auth/controllers/v1/auth.py
+++ b/st2auth/st2auth/controllers/v1/auth.py
@@ -21,7 +21,8 @@ from six.moves import http_client
 from oslo_config import cfg
 
 from st2common.exceptions.auth import TokenNotFoundError, TokenExpiredError
-from st2common.exceptions.auth import TTLTooLargeException, UserNotFoundError
+from st2common.exceptions.auth import UserNotFoundError, AmbiguousUserError
+from st2common.exceptions.auth import NoNicknameOriginProvidedError, TTLTooLargeException
 from st2common.models.api.base import jsexpose
 from st2common.models.api.auth import TokenAPI
 from st2common.persistence.auth import User
@@ -126,17 +127,29 @@ class TokenController(rest.RestController):
         if result is True:
             ttl = getattr(request, 'ttl', None)
             impersonate_user = getattr(request, 'user', None)
-
             if impersonate_user is not None:
                 username = impersonate_user
             else:
                 impersonate_user = getattr(request, 'impersonate_user', None)
+                nickname_origin = getattr(request, 'impersonate_from', None)
             if impersonate_user is not None:
                 try:
-                    username = User.get_by_chatops_id(impersonate_user).username
-                except UserNotFoundError:
-                    message = "Could not locate user with chatops_id '%s'" % \
+                    username = User.get_by_nickname(impersonate_user, nickname_origin).username
+                except NoNicknameOriginProvidedError:
+                    message = "Nickname origin is not provided for nickname '%s'" % \
                               impersonate_user
+                    self._abort_request(status_code=http_client.BAD_REQUEST,
+                                        message=message)
+                    return
+                except UserNotFoundError:
+                    message = "Could not locate user %s@%s" % \
+                              (impersonate_user, nickname_origin)
+                    self._abort_request(status_code=http_client.BAD_REQUEST,
+                                        message=message)
+                    return
+                except AmbiguousUserError:
+                    message = "%s@%s matched more than one username" % \
+                              (impersonate_user, nickname_origin)
                     self._abort_request(status_code=http_client.BAD_REQUEST,
                                         message=message)
                     return

--- a/st2common/st2common/exceptions/auth.py
+++ b/st2common/st2common/exceptions/auth.py
@@ -25,7 +25,9 @@ __all__ = [
     'ApiKeyNotFoundError',
     'MultipleAuthSourcesError',
     'NoAuthSourceProvidedError',
-    'UserNotFoundError'
+    'NoNicknameOriginProvidedError',
+    'UserNotFoundError',
+    'AmbiguousUserError',
 ]
 
 
@@ -65,5 +67,13 @@ class NoAuthSourceProvidedError(StackStormBaseException):
     pass
 
 
+class NoNicknameOriginProvidedError(StackStormBaseException):
+    pass
+
+
 class UserNotFoundError(StackStormBaseException):
+    pass
+
+
+class AmbiguousUserError(StackStormBaseException):
     pass

--- a/st2common/st2common/models/db/auth.py
+++ b/st2common/st2common/models/db/auth.py
@@ -33,7 +33,8 @@ __all__ = [
 class UserDB(stormbase.StormFoundationDB):
     name = me.StringField(required=True, unique=True)
     is_service = me.BooleanField(required=True, default=False)
-    chatops_id = me.StringField(required=False, unique=True)
+    nicknames = me.DictField(required=False,
+                             help_text='"Nickname + origin" pairs for ChatOps auth')
 
     def get_roles(self):
         """

--- a/st2common/st2common/persistence/auth.py
+++ b/st2common/st2common/persistence/auth.py
@@ -36,9 +36,9 @@ class User(Access):
 
         result = cls.query(**{('nickname__%s' % origin): nickname})
 
-        if not result:
+        if not result.first():
             raise UserNotFoundError()
-        if result.count > 1:
+        if result.count() > 1:
             raise AmbiguousUserError()
 
         return result.first()


### PR DESCRIPTION
Store a dict of nickname-origin pairs instead of just one chatops_id string to make the field more future-proof. We may not need it immediately, but some features that will require this change are already planned.